### PR TITLE
Add Unicode support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# This file is for zig-specific build artifacts.
+
+.zig-cache/
+zig-out/
+build/
+build-*/
+docgen_tmp/
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+*.elf
+*.ko
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,11 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
+    const zg = b.dependency("zg", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
     _ = b.addModule("fuzzig", .{ .root_source_file = b.path("src/root.zig") });
 
     const lib = b.addStaticLibrary(.{
@@ -13,6 +18,12 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    lib.root_module.addImport("code_point", zg.module("code_point"));
+    lib.root_module.addImport("GenCatData", zg.module("GenCatData"));
+    lib.root_module.addImport("CaseData", zg.module("CaseData"));
+    lib.root_module.addImport("Normalize", zg.module("Normalize"));
+    lib.root_module.addImport("CaseFold", zg.module("CaseFold"));
+
     b.installArtifact(lib);
 
     const lib_unit_tests = b.addTest(.{
@@ -20,6 +31,12 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
+
+    lib_unit_tests.root_module.addImport("code_point", zg.module("code_point"));
+    lib_unit_tests.root_module.addImport("GenCatData", zg.module("GenCatData"));
+    lib_unit_tests.root_module.addImport("CaseData", zg.module("CaseData"));
+    lib_unit_tests.root_module.addImport("Normalize", zg.module("Normalize"));
+    lib_unit_tests.root_module.addImport("CaseFold", zg.module("CaseFold"));
 
     const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -38,6 +38,10 @@
         //    // computed. This field and `url` are mutually exclusive.
         //    .path = "foo",
         //},
+        .zg = .{
+            .url = "https://codeberg.org/dude_the_builder/zg/archive/v0.13.2.tar.gz",
+            .hash = "122055beff332830a391e9895c044d33b15ea21063779557024b46169fb1984c6e40",
+        },
     },
 
     // Specifies the set of files and directories that are included in this package.

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1,5 +1,8 @@
 const std = @import("std");
 
+const GenCatData = @import("GenCatData");
+const CaseData = @import("CaseData");
+
 pub fn digitCount(v: anytype) usize {
     const abs: u32 = @intCast(@abs(v));
     if (abs == 0) return 1;
@@ -27,6 +30,33 @@ pub const CharacterType = enum {
             0 => .Empty,
             else => .Lower,
         };
+    }
+
+    pub fn fromUnicode(c: u21, allocator: std.mem.Allocator) CharacterType {
+        const cd = CaseData.init(allocator) catch @panic("Memory error");
+        defer cd.deinit();
+        const gcd = GenCatData.init(allocator) catch @panic("Memory error");
+        defer gcd.deinit();
+        if (cd.isLower(c)) {
+            return .Lower;
+        } else if (cd.isUpper(c)) {
+            return .Upper;
+        } else if (gcd.isNumber(c)) {
+            return .Number;
+        } else if (switch (c) {
+            ' ', '\\', '/', '|', '(', ')', '[', ']', '{', '}' => true,
+            else => false,
+        }) {
+            return .HardSeperator;
+        } else if (gcd.isSeparator(c)) {
+            return .HardSeperator;
+        } else if (gcd.isPunctuation(c) or gcd.isSymbol(c) or gcd.isMark(c)) {
+            return .SoftSeperator;
+        } else if (gcd.isControl(c)) {
+            return .Empty;
+        } else {
+            return .Lower; // Maybe .Empty instead ?
+        }
     }
 
     const Role = enum {


### PR DESCRIPTION
This PR add a working Unicode support. Why not UTF-8 ? Because UTF-8 is as complex as Unicode, so directly support Unicode.
I added a dependence, the library [zg](https://codeberg.org/dude_the_builder/zg) to properly handle Unicode complexity.
I made no breaking change to the existing high level API, but some little modification.
There is not a lot of test, but it can be good to check if all is good.

To catch error, I used the panic handler `@panic` to avoid returning an error. For why ? Don't make breaking changes.

I am planning another PR to remove the obligation of knowing the max size of the haystack and needle at algorithm initialisation, but it will be a big breaking change, and it is not done for the moment. I will surely replace the panic by standard error in these changes.